### PR TITLE
Remove log dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,11 @@
 [package]
-
 name = "mozprofile"
 version = "0.2.0"
 authors = ["Mozilla Tools and Automation <auto-tools@mozilla.com>"]
 description = "Library for working with Mozilla profiles."
 repository = "https://github.com/jgraham/rust_mozprofile"
 license = "MPL-2.0"
-license-file = "LICENSE"
 
 [dependencies]
-log = "0.3"
 tempdir = "0.3.4"
 lazy_static = "0.1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,4 @@
 #[macro_use]
-extern crate log;
-#[macro_use]
 extern crate lazy_static;
 
 extern crate tempdir;

--- a/src/profile.rs
+++ b/src/profile.rs
@@ -27,8 +27,6 @@ impl Profile {
             }
         };
 
-        info!("Using profile path {}", path.to_str().unwrap());
-
         Ok(Profile {
             path: path,
             temp_dir: temp_dir,


### PR DESCRIPTION
There is a single call to the info!() macro in the code base for a field
that is being set on the returned Profile struct.  It is more useful
for consumers to log the profile's path if they are interested in it.

This removes the log crate as a dependency.