### PR TITLE
Don't panic on empty input.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -180,6 +180,14 @@ mod test {
    }
 
     #[test]
+    fn serialize_empty() {
+        let input = "";
+        let expected = "";
+
+        serialize_test(input, expected);
+    }
+
+    #[test]
     fn serialize_simple() {
         let input = "  user_pref /* block comment */ ( 'example.pref.string', 'value' )   ;\n pref(\"example.pref.int\", -123); sticky_pref('example.pref.bool',false)";
         let expected = "sticky_pref(\"example.pref.bool\", false);

--- a/src/prefreader.rs
+++ b/src/prefreader.rs
@@ -257,21 +257,21 @@ impl<'a> PrefTokenizer<'a> {
     }
 
     fn get_char(&mut self) -> Option<char> {
-        if self.pos >= self.data.len() - 1 {
+        if self.pos as i64 >= self.data.len() as i64 - 1 {
             self.cur = None;
             return None
         };
         if self.cur.is_some() {
             self.pos += 1;
         }
-        let c = self.data[self.pos] as char;
         if self.cur == Some('\n') {
             self.position.line += 1;
             self.position.column = 0;
         } else if self.cur.is_some() {
             self.position.column += 1;
         };
-        self.cur = Some(c);
+        self.cur = self.data.get(self.pos)
+            .map(|c| *c as char);
         self.cur
     }
 


### PR DESCRIPTION
Previously on empty input we had an overflow that led to a
panic. Avoid the overflow and also ensure that even with the overflow
we no longer panic by removing the index access.